### PR TITLE
A new configurator?

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -1,47 +1,17 @@
-"""
-Poor Man's Configurator. Probably a terrible idea. Example usage:
-$ python train.py config/override_file.py --batch_size=32
-this will first run config/override_file.py, then override batch_size to 32
+class Config:
+    def __init__(self, config_file=None, **kwargs):
+        if config_file is not None:
+            with open(config_file) as f:
+                print(f"Overriding config with {config_file}:")
+                print(f.read())
+                exec(f.read(), self.__dict__)
 
-The code in this file will be run as follows from e.g. train.py:
->>> exec(open('configurator.py').read())
-
-So it's not a Python module, it's just shuttling this code away from train.py
-The code in this script then overrides the globals()
-
-I know people are not going to love this, I just really dislike configuration
-complexity and having to prepend config. to every single variable. If someone
-comes up with a better simple Python solution I am all ears.
-"""
-
-import sys
-from ast import literal_eval
-
-for arg in sys.argv[1:]:
-    if '=' not in arg:
-        # assume it's the name of a config file
-        assert not arg.startswith('--')
-        config_file = arg
-        print(f"Overriding config with {config_file}:")
-        with open(config_file) as f:
-            print(f.read())
-        exec(open(config_file).read())
-    else:
-        # assume it's a --key=value argument
-        assert arg.startswith('--')
-        key, val = arg.split('=')
-        key = key[2:]
-        if key in globals():
+        for key, val in kwargs.items():
             try:
-                # attempt to eval it it (e.g. if bool, number, or etc)
                 attempt = literal_eval(val)
             except (SyntaxError, ValueError):
-                # if that goes wrong, just use the string
                 attempt = val
-            # ensure the types match ok
-            assert type(attempt) == type(globals()[key])
-            # cross fingers
+            if hasattr(self, key):
+                assert isinstance(attempt, type(getattr(self, key)))
             print(f"Overriding: {key} = {attempt}")
-            globals()[key] = attempt
-        else:
-            raise ValueError(f"Unknown config key: {key}")
+            setattr(self, key, attempt)


### PR DESCRIPTION
@Liuhong99 Hi 👋🏻,

I might have a simple solution for `configurator.py`: a shift from global configuration management to a class-based approach

main goals:

1. **separation of concerns**: By using a `Config` class to encapsulate configuration management, we separate this concern from the command-line argument parsing. This makes code more maintainable.
2. **selective import**: Instead of importing every variable globally, we can selectively import frequently used or important variables, without needing to prepend `config.` to every single variable.

and then in the scripts where these configs are needed, could do this:
```python
from configurator import config

batch_size = config.batch_size
learning_rate = config.learning_rate

"""
now we use 'batch_size' and 'learning_rate' directly in the script
and avoid typing 'config.' before each variable.
"""
``` 