### PR TITLE
Use pytorch2 optimized native attention

### DIFF
--- a/model.py
+++ b/model.py
@@ -48,7 +48,6 @@ class CausalSelfAttention(nn.Module):
         self.idx_layer = idx_layer
         self.scale_attn_by_inverse_layer_idx = config.scale_attn_by_inverse_layer_idx
         
-
         self.flash = hasattr(torch.nn.functional, 'scaled_dot_product_attention')
         if not self.flash:
             print("Using slow attention. Flash Attention requires PyTorch >= 2.0")

--- a/model.py
+++ b/model.py
@@ -66,7 +66,6 @@ class CausalSelfAttention(nn.Module):
 
         if self.flash:
             # efficient attention using Flash Attention CUDA kernels
-#            print("Using pytorch flash attention")
             y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=None, dropout_p=self.dropout if self.training else 0, is_causal=True)
         else:
             # manual implementation of attention


### PR DESCRIPTION
Hi, here is a pull request for a small speedup where attention is computed using pytorch 2 function "torch.nn.functional.scaled_dot_product_attention" if available.

Makes the optimizer run about 10% faster according to a bit of testing I did

This optimization was essentially copied from a recent version of nanoGPT
